### PR TITLE
Added runtime error in case radii of torus do not match

### DIFF
--- a/torch_topological/data/shapes.py
+++ b/torch_topological/data/shapes.py
@@ -162,6 +162,12 @@ def sample_from_torus(n, d=3, r=1.0, R=2.0, seed=None):
     torch.tensor of shape `(n, d)`
         Tensor of sampled coordinates.
     """
+    if r > R:
+        raise RuntimeError(
+            'Radius of the tube must be less than or equal to radius of the torus'
+        )
+
+ 
     rng = np.random.default_rng(seed)
     angles = []
 


### PR DESCRIPTION
A larger radius of the tube of a torus than the one of the torus itself does not lead to a geometrically meaningful object, therefore a runtime error will be thrown.