### PR TITLE
fix: Apply scale parameter within `exp` in MultiScaleKernel

### DIFF
--- a/torch_topological/nn/multi_scale_kernel.py
+++ b/torch_topological/nn/multi_scale_kernel.py
@@ -131,8 +131,8 @@ class MultiScaleKernel(torch.nn.Module):
             # diagram 2
             denom = self._dist(D1, self._mirror(D2), p)
 
-            M = torch.exp(-nom) / (8 * self.sigma)
-            M -= torch.exp(-denom) / (8 * self.sigma)
+            M = torch.exp(-nom / (8 * self.sigma))
+            M -= torch.exp(-denom / (8 * self.sigma))
 
             # sum over all points
             k_sigma += M.sum() / (8. * self.sigma * torch.pi)


### PR DESCRIPTION
It appears that there is a typo in the implementation of `MultiScaleKernel`. Namely, @pjhartout and I would expect that the scale parameter `self.sigma` should be applied *before* exponentiation in these two lines:
https://github.com/aidos-lab/pytorch-topological/blob/aba14745e9617089d25298e0355d582e464c3da0/torch_topological/nn/multi_scale_kernel.py#L134
https://github.com/aidos-lab/pytorch-topological/blob/aba14745e9617089d25298e0355d582e464c3da0/torch_topological/nn/multi_scale_kernel.py#L135
For reference, consider equation 10 in https://arxiv.org/pdf/1412.6821. 
In the current implementation, `self.sigma` only acts as a multiplicative factor on the kernel and thereby does not meaningfully change its behavior. 

This PR fixes the two lines above. The tests are passing locally for me.
